### PR TITLE
Makefile: Add missing GLPlugin dependency

### DIFF
--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -9,6 +9,7 @@ GL_MODULES=\
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/CSF.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/Item.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/SysDescPrettify.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/TableItem.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/MGSNMPUPSMIB.pm \


### PR DESCRIPTION
Without:

```
$ ./plugins-scripts/check_rittal_health
Can't locate Monitoring/GLPlugin/SNMP/SysDescPrettify.pm in @INC (you may need to install the Monitoring::GLPlugin::SNMP::SysDescPrettify module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.3 /usr/local/share/perl/5.30.3 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl) at ./plugins-scripts/check_rittal_health line 2673.
```